### PR TITLE
Fix Setting ID

### DIFF
--- a/src/main/webapp/WEB-INF/templates/manage-integrations.twig
+++ b/src/main/webapp/WEB-INF/templates/manage-integrations.twig
@@ -151,7 +151,7 @@
                     <div class="col-sm-9">
                         <select class="form-control mutable-setting"
                                 title="Enable Slack Webhooks"
-                                id="sync_db.enable"
+                                id="slack.enable"
                                 required>
                             <option value="true" {% if(slack_enable) %}selected{% endif %}>Yes</option>
                             <option value="false" {% if(not(slack_enable)) %}selected{% endif %}>No</option>


### PR DESCRIPTION
Setting ID for Slack Webhook enable was incorrect, which prevented it from being enabled.